### PR TITLE
Copied in the stdcopy from dc702b6c6bda5cd2d530e86804627c1a5a155e3c

### DIFF
--- a/pkg/stdcopy/stdcopy_test.go
+++ b/pkg/stdcopy/stdcopy_test.go
@@ -17,10 +17,9 @@ func TestNewStdWriter(t *testing.T) {
 }
 
 func TestWriteWithUnitializedStdWriter(t *testing.T) {
-	writer := StdWriter{
-		Writer:  nil,
-		prefix:  Stdout,
-		sizeBuf: make([]byte, 4),
+	writer := stdWriter{
+		Writer: nil,
+		prefix: byte(Stdout),
 	}
 	n, err := writer.Write([]byte("Something here"))
 	if n != 0 || err == nil {
@@ -72,7 +71,7 @@ func TestWriteWithWriterError(t *testing.T) {
 		t.Fatalf("Didn't get expected error.")
 	}
 	if n != expectedReturnedBytes {
-		t.Fatalf("Didn't get expected writen bytes %d, got %d.",
+		t.Fatalf("Didn't get expected written bytes %d, got %d.",
 			expectedReturnedBytes, n)
 	}
 }
@@ -180,7 +179,7 @@ func TestStdCopyDetectsCorruptedFrame(t *testing.T) {
 		src:          buffer}
 	written, err := StdCopy(ioutil.Discard, ioutil.Discard, reader)
 	if written != startingBufLen {
-		t.Fatalf("Expected 0 bytes read, got %d", written)
+		t.Fatalf("Expected %d bytes read, got %d", startingBufLen, written)
 	}
 	if err != nil {
 		t.Fatal("Didn't get nil error")


### PR DESCRIPTION
We think this is a bug for for the Unrecognized input header issue:
- https://github.com/Shopify/locutus/issues/472

Here is a test that can reproduce the problem in docker:
- https://gist.github.com/dpiddy/c3a071ee591d6e8e9617

The bug appears to be in some library code pkg/stdcopy.  Some fixes have been applied to the docker repo.  That now allow this test to pass.

Please review stuff:
@airhorns @Shopify/borg 
