### PR TITLE
Fixed build issue that prevents make test from working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -193,7 +193,7 @@ RUN ./contrib/download-frozen-image.sh /docker-frozen-images \
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone -b v1.0.3 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
-	&& git clone -b v1.2 https://github.com/russross/blackfriday.git "$GOPATH/src/github.com/russross/blackfriday" \
+	&& git clone -b v1.4 https://github.com/russross/blackfriday.git "$GOPATH/src/github.com/russross/blackfriday" \
 	&& go get -v -d github.com/cpuguy83/go-md2man \
 	&& go build -v -o /usr/local/bin/go-md2man github.com/cpuguy83/go-md2man \
 	&& rm -rf "$GOPATH"


### PR DESCRIPTION
I am trying to build the Shopify fork of docker.  When I run tests, it fails because of some 3rd party dependency.   This is only to generate the man pages, AFAIK. So, this should not effect the binaries used in the release.

https://github.com/docker/docker/issues/19787
https://github.com/solanolabs/docker/commit/bd00bdc5cae26b3a4994e9d2cbac7439d7c2b767

Please review:
@Shopify/borg 
